### PR TITLE
Added a check for bad fiddler test frames.  

### DIFF
--- a/Source/RulesEngine/ServiceCallItem.cs
+++ b/Source/RulesEngine/ServiceCallItem.cs
@@ -383,6 +383,12 @@ namespace XboxLiveTrace
                         return null;
                     }
 
+                    // Fiddler Test Frames can cause LTA to break.  This filters out those fames.
+                    if (firstLineSplit[1].Contains("http:///"))
+                    {
+                        return null;
+                    }
+
                     frame.m_isGet = firstLineSplit[0].Equals("GET");
 
                     // Extract the XUID (if any) from the first line of the client side of the frame

--- a/Source/RulesEngine/ServiceCallItem.cs
+++ b/Source/RulesEngine/ServiceCallItem.cs
@@ -384,7 +384,7 @@ namespace XboxLiveTrace
                     }
 
                     // Fiddler Test Frames can cause LTA to break.  This filters out those fames.
-                    if (firstLineSplit[1].Contains("http:///"))
+                    if (firstLineSplit[1].StartsWith("http:///", true, null))
                     {
                         return null;
                     }


### PR DESCRIPTION
It seems that some Fiddler clients will dump the occasional "test frame" into their captures.  It's possible this is from user error in setting up Fiddler.  In looking at multiple captures that contain missing frames, they all seem to start with "http:///" so this checks for that and if so, nulls out that frame.  

It's possible it would make other "malformed" but seemingly valid frames get dropped as well though it seems like this is both the fastest test for the issue AND hasn't turned up a false positive yet.