### PR TITLE
Small batch detection was using <= instead of <

### DIFF
--- a/Source/Rules/SmallBatchDetectionRule.cs
+++ b/Source/Rules/SmallBatchDetectionRule.cs
@@ -87,7 +87,7 @@ namespace XboxLiveTrace
                             if (values != null)
                             {
                                 matchesFoundDict.Add(thisItem, values.Count);
-                                if (values.Count <= m_minBatchXUIDsPerBatchCall)
+                                if (values.Count < m_minBatchXUIDsPerBatchCall)
                                 {
                                     lowXUIDInstancesFound++;
                                     description.Clear();


### PR DESCRIPTION
At least the way the tests reads, a small batch min size for say profile.xboxlive.com should be 2.  With the code the way it is, when a batch of 2 is detected it flags it as being too small.  This fixed that issue.