### PR TITLE
Quick fix for SmallBatchDetection_Profile_Rule

### DIFF
--- a/Source/XboxLiveTraceAnalyzer.Rules.json
+++ b/Source/XboxLiveTraceAnalyzer.Rules.json
@@ -224,7 +224,7 @@
         "Endpoint": "profile.xboxlive.com",
         "Properties":
         {
-            "MinBatchXUIDsPerBatchCall": "2",
+            "MinBatchXUIDsPerBatchCall": "1",
             "MatchPatterns": [
             {
                 "BatchURI": "/users/batch/profile/settings",


### PR DESCRIPTION
Changed MinBatchXUIDsPerBatchCall to 1 for SmallBatchDetection_Profile_Rule to fix issues with 1 XUID being passed with rest call '/users/batch/profile/settings' in GetUserProfileAsync.