### PR TITLE
Adding more debug logs to Xbox Live Trace Analyzer

### DIFF
--- a/Source/RulesEngine/ServiceCallData.cs
+++ b/Source/RulesEngine/ServiceCallData.cs
@@ -137,6 +137,7 @@ namespace XboxLiveTrace
 
             List<ServiceCallItem> frameData = new List<ServiceCallItem>();
 
+            int frameNumber = 1;
             // Process data per frame
             foreach (var group in result)
             {
@@ -147,12 +148,20 @@ namespace XboxLiveTrace
 
                 ServiceCallItem frame = null;
 
+                System.Diagnostics.Debug.WriteLine("Analyzing Frame# " + frameNumber);
+                frameNumber++;
+
                 frame = ServiceCallItem.FromFiddlerFrame((UInt32)group.Frame, cFileArchive, mFileArchive, sFileArchive, o => m_allEndpoints || Utils.IsAnalyzedService(o, customAgent));
 
                 // If this is not an Xbox Service Endpoint that we are checking, then move along.
                 if (frame == null)
                 {
+                    System.Diagnostics.Debug.WriteLine("Skipping\r\n");
                     continue;
+                }
+                else
+                {
+                    System.Diagnostics.Debug.WriteLine("Processing Call\r\n");
                 }
 
                 frameData.Add(frame);

--- a/Source/RulesEngine/ServiceCallItem.cs
+++ b/Source/RulesEngine/ServiceCallItem.cs
@@ -305,6 +305,7 @@ namespace XboxLiveTrace
 
         public static ServiceCallItem FromFiddlerFrame(UInt32 frameId, ZipArchiveEntry cFileStream, ZipArchiveEntry mFileStream, ZipArchiveEntry sFileStream, Func<WebHeaderCollection, bool> filterCallback)
         {
+
             ServiceCallItem frame = new ServiceCallItem();
             frame.m_id = frameId;
 
@@ -320,12 +321,14 @@ namespace XboxLiveTrace
                     // CONNECT Frames should not be in the analysis.
                     if (firstLineSplit[0] == "CONNECT")
                     {
+                        System.Diagnostics.Debug.WriteLine("CONNECT Frames should not be in the analysis.");
                         return null;
                     }
 
                     // Fiddler Test Frames can cause LTA to break.  This filters out those fames.
                     if (firstLineSplit[1].StartsWith("http:///", true, null))
                     {
+                        System.Diagnostics.Debug.WriteLine("Fiddler Test Frames should not be in the analysis.");
                         return null;
                     }
 
@@ -357,6 +360,7 @@ namespace XboxLiveTrace
                         fileLine = cFile.ReadLine();
                     }
 
+                    System.Diagnostics.Debug.WriteLine("Analyzing " + frame.m_uri);
                     // Filter calls with headers
                     if (filterCallback!= null && !filterCallback(reqHeaders))
                     {

--- a/Source/RulesEngine/Utils.cs
+++ b/Source/RulesEngine/Utils.cs
@@ -102,11 +102,85 @@ namespace XboxLiveTrace
 
         public static bool IsAnalyzedService(WebHeaderCollection headers, String customUserAgent)
         {
-            return ((headers["x-xbl-api-build-version"] != null && headers["x-xbl-api-build-version"].Equals("adk", StringComparison.OrdinalIgnoreCase))
-                || (headers["User-Agent"]!= null && headers["User-Agent"].Contains("XboxServicesAPI") && headers["x-xbl-client-name"] == null)
-                || headers["X-XBL-Build-Version"] != null  // XCE CS1.0 event
-                || headers["X-AuthXToken"] != null  // UTC upload CS2.1 events
-                || (!String.IsNullOrEmpty(customUserAgent) && headers["User-Agent"] == customUserAgent));
+            var result = false;
+            if (headers["x-xbl-api-build-version"] != null && headers["x-xbl-api-build-version"].Equals("adk", StringComparison.OrdinalIgnoreCase))
+            {
+                System.Diagnostics.Debug.WriteLine("header[x-xbl-api-build-version] is adk");
+                result = true;
+            }
+            else
+            {
+                if (headers["x-xbl-api-build-version"] == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("header[x-xbl-api-build-version] is null");
+                }
+                else
+                {
+                    System.Diagnostics.Debug.WriteLine("header[x-xbl-api-build-version] is not adk");
+                }
+            }
+
+            if (headers["User-Agent"] != null && headers["User-Agent"].Contains("XboxServicesAPI") && headers["x-xbl-client-name"] == null)
+            {
+                System.Diagnostics.Debug.WriteLine("header[User-Agent] contains XboxServicesAPI and header[x-xbl-client-name] is null");
+                result = true;
+            }
+            else
+            {
+                if (headers["User-Agent"] == null)
+                {
+                    System.Diagnostics.Debug.WriteLine("header[User-Agent] is null");
+                }
+                else if (!headers["User-Agent"].Contains("XboxServicesAPI"))
+                {
+                    System.Diagnostics.Debug.WriteLine("header[User-Agent] does not contain XboxServicesAPI");
+                }
+                else
+                {
+                    System.Diagnostics.Debug.WriteLine("header[x-xbl-client-name] is not null");
+                }
+            }
+
+            // XCE CS1.0 event
+            if (headers["X-XBL-Build-Version"] != null)
+            {
+                System.Diagnostics.Debug.WriteLine("header[X-XBL-Build-Version] is not null");
+                result = true;
+            }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine("header[X-XBL-Build-Version] is null");
+            }
+
+            // UTC upload CS2.1 events
+            if (headers["X-AuthXToken"] != null)
+            {
+                System.Diagnostics.Debug.WriteLine("header[X-AuthXToken] is not null");
+                result = true;
+            }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine("header[X-AuthXToken] is null");
+            }
+
+            if (!String.IsNullOrEmpty(customUserAgent) && headers["User-Agent"] == customUserAgent)
+            {
+                System.Diagnostics.Debug.WriteLine("customUserAgent is not null and header[User-Agent] matches.");
+                result = true;
+            }
+            else
+            {
+                if (String.IsNullOrEmpty(customUserAgent))
+                {
+                    System.Diagnostics.Debug.WriteLine("customUserAgent is null or empty");
+                }
+                else
+                {
+                    System.Diagnostics.Debug.WriteLine("header[User-Agent] does not match customUserAgent");
+                }
+            }
+
+            return result;
         }
 
         public static String GeneratePathToFile(String file)


### PR DESCRIPTION
These logs provide a more detailed view of why certain frames/requests were skipped or analyzed.