### PR TITLE
Update preCompileScript.cmd

### DIFF
--- a/Utilities/Pipelines/Scripts/preCompileScript.cmd
+++ b/Utilities/Pipelines/Scripts/preCompileScript.cmd
@@ -1,14 +1,33 @@
+@echo off
+
+setlocal enabledelayedexpansion
+
 rem See https://microsoft.sharepoint.com/teams/osg_xboxtv/xengsrv/SitePages/Extensibility%20Hooks.aspx for details
 rem if '%TFS_IsFirstBuild%' NEQ 'True' goto done
+
 echo Running preCompileScript.cmd
 
-call %TFS_SourcesDirectory%\setBuildVersion.cmd
+call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat"
+
+set SDK_RELEASE_YEAR=2022
+set SDK_RELEASE_MONTH=04
+
+set "buildVersionTxt="
+set /p buildVersionTxt=</BuildVersion.txt
+if "%buildVersionTxt%"=="" set /p buildVersionTxt= <../BuildVersion.txt
+if "%buildVersionTxt%"=="" set /p buildVersionTxt= <../../BuildVersion.txt
+if "%buildVersionTxt%"=="" goto err
+
+echo %buildVersionTxt%
+
+set SDK_RELEASE_YEAR=!buildVersionTxt:~0,4!
+set SDK_RELEASE_MONTH=!buildVersionTxt:~5,7!
 
 rem format release numbers
-FOR /F "TOKENS=1 eol=/ DELIMS=. " %%A IN ("%TFS_VersionNumber%") DO SET SDK_POINT_NAME_YEARMONTH=%%A
-FOR /F "TOKENS=2 eol=/ DELIMS=. " %%A IN ("%TFS_VersionNumber%") DO SET SDK_POINT_NAME_DAYVER=%%A
-set SDK_POINT_NAME_YEAR=%SDK_POINT_NAME_YEARMONTH:~0,2%
-set SDK_POINT_NAME_MONTH=%SDK_POINT_NAME_YEARMONTH:~2,2%
+set SDK_POINT_NAME_YEARMONTH=%TFS_VersionNumber:~0,4%
+set SDK_POINT_NAME_DAYVER=%TFS_VersionNumber:~5,9%
+set SDK_POINT_NAME_YEAR=%SDK_POINT_NAME_YEARMONTH:~2,2%
+set SDK_POINT_NAME_MONTH=%SDK_POINT_NAME_YEARMONTH:~0,2%
 set SDK_POINT_NAME_DAY=%SDK_POINT_NAME_DAYVER:~0,2%
 set SDK_POINT_NAME_VER=%SDK_POINT_NAME_DAYVER:~2,9%
 
@@ -33,4 +52,8 @@ type %TOOL_VERSION_FILE%
 type %TOOL_RULES_FILE%
 
 echo Done preCompileScript.cmd
-:done
+goto :eof
+
+:err
+echo Couldn't find BuildVersion.txt
+goto :eof


### PR DESCRIPTION
This code sets the SDK_RELEASE_YEAR and SDK_RELEASE_MONTH values to 2022 and 04, respectively. It also adds a call to vcvarsamd64_x86.bat to set up the Visual Studio environment.

It also uses delayed expansion to set the values of SDK_RELEASE_YEAR and SDK_RELEASE_MONTH based on the contents of the BuildVersion.txt file. The script will search for BuildVersion.txt in several locations if it's not found in the current directory.