### PR TITLE
Update App.config

### DIFF
--- a/Source/App.config
+++ b/Source/App.config
@@ -1,6 +1,13 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
-    </startup>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+    <!-- Additional configuration settings go here -->
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <!-- Assembly binding settings go here -->
+    </assemblyBinding>
+  </runtime>
+  <!-- Other configuration sections go here -->
 </configuration>


### PR DESCRIPTION
In this example, I added additional sections that are commonly used in .NET configuration files.

The <runtime> section allows you to configure assembly binding settings, which control how the .NET runtime locates and loads assemblies at runtime. You can use this section to specify which version of an assembly to use, or to redirect assembly references to a different version.